### PR TITLE
Prevent IndexError while handling CursorMoveUp

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -377,8 +377,10 @@ class Ansi2HTMLConverter(object):
             # Go back, deleting every token in the last 'line'
             if part == CursorMoveUp:
                 final_parts.pop()
-                while '\n' not in final_parts[-1]:
-                    final_parts.pop()
+
+                if final_parts:
+                    while '\n' not in final_parts[-1]:
+                        final_parts.pop()
 
                 continue
 


### PR DESCRIPTION
Sometime `final_parts[-1]` is not available and cause `IndexError` exception.