### PR TITLE
Fix missing color CSS definitions

### DIFF
--- a/ansi2html/style.py
+++ b/ansi2html/style.py
@@ -96,6 +96,15 @@ def get_styles(dark_bg=True, scheme='ansi2html'):
         css.append(Rule('.ansi4%s' % _index, background_color=pal[_index]))
         css.append(Rule('.inv4%s' % _index, color=pal[_index]))
 
+    # set palette colors in 256 color encoding
+    pal = SCHEME[scheme]
+    for _index in range(len(pal)):
+        css.append(Rule('.ansi38-%s' % _index, color=pal[_index]))
+        css.append(Rule('.inv38-%s' % _index, background_color=pal[_index]))
+    for _index in range(len(pal)):
+        css.append(Rule('.ansi48-%s' % _index, background_color=pal[_index]))
+        css.append(Rule('.inv48-%s' % _index, color=pal[_index]))
+
     # css.append("/* Define the explicit color codes (obnoxious) */\n\n")
 
     for green in range(0, 6):

--- a/ansi2html/style.py
+++ b/ansi2html/style.py
@@ -61,8 +61,11 @@ SCHEME = { # black red green brown/yellow blue magenta cyan grey/white
 
     # http://ethanschoonover.com/solarized
     'solarized': ("#262626", "#d70000", "#5f8700", "#af8700", "#0087ff",
-                  "#af005f", "#00afaf", "#e4e4e4"),
+                  "#af005f", "#00afaf", "#e4e4e4",
+                  "#1c1c1c", "#d75f00", "#585858", "#626262", "#808080",
+                  "#5f5faf", "#8a8a8a", "#ffffd7", ),
     }
+
 
 def get_styles(dark_bg=True, scheme='ansi2html'):
 


### PR DESCRIPTION
To reproduce the problem, set your taskwarrior colorscheme to solarized-dark, and run:

    $ task rc._forcecolor:yes burndown | ansi2html -s solarized > test.html

The colors will not be visible, since colors from basic 16 color pallete are encoded in the extended manner (38-0 .. 38-15), thus resulting into unknown CSS classes.