### PR TITLE
six is called six, not python-six

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [bdist_rpm]
 requires = python >= 2.6.6
-           python-six >= 1.7.3
+           six >= 1.7.3


### PR DESCRIPTION
when building six with bdis_rpm the rpm is named six, not python-six.