### PR TITLE
enable python 3 input decoding

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -24,6 +24,7 @@ import re
 import sys
 import optparse
 import pkg_resources
+import io
 
 try:
     from collections import OrderedDict
@@ -515,10 +516,11 @@ def main():
         title=opts.output_title,
     )
 
+    if six.PY3:
+        sys.stdin = io.TextIOWrapper(sys.stdin.detach(), opts.input_encoding, "replace")
+
     def _read(input_bytes):
         if six.PY3:
-            # This is actually already unicode.  How to we explicitly decode in
-            # python3?  I don't know the answer yet.
             return input_bytes
         else:
             return input_bytes.decode(opts.input_encoding)


### PR DESCRIPTION
This set's up a ```TEXTIOWrapper``` for sys.stdin which let's us set the desired encoding.
Also sets the error-mode to "replace".

Default behaviour leads to this for fairly standard shell output:

```
$ cat output.txt | ansi2html
Traceback (most recent call last):
  File "/usr/bin/ansi2html", line 9, in <module>
    load_entry_point('ansi2html==1.1.0', 'console_scripts', 'ansi2html')()
  File "/usr/lib/python3.5/site-packages/ansi2html/converter.py", line 542, in main
    output = conv.convert("".join(sys.stdin.readlines()), full=full, ensure_trailing_newline=True)
  File "/usr/lib/python3.5/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf3 in position 5493: invalid continuation byte
```

(on Arch linux with utf-8 locale)