### PR TITLE
Give more useful TaskWarrior example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Example - Shell Usage
 
  $ ls --color=always | ansi2html > directories.html
  $ sudo tail /var/log/messages | ccze -A | ansi2html > logs.html
- $ task burndown | ansi2html > burndown.html
+ $ task rc._forcecolor:yes limit:0 burndown | ansi2html > burndown.html
 
 See the list of full options with::
 


### PR DESCRIPTION
TaskWarrior (as of version 2.5.1)--when it detects that output is not
going to a real terminal--will turn off color and set line limit (the
latter is subject to change suggested in [a feature request][tw1828]).

Adding `rc._forcecolor:yes` and `limit:0` to argument list prevents both
effects.

  [tw1828]: https://bug.tasktools.org/browse/TW-1828