### PR TITLE
Revert "six is called six, not python-six"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [bdist_rpm]
 requires = python >= 2.6.6
-           six >= 1.7.3
+           python-six >= 1.7.3


### PR DESCRIPTION
Reverts ralphbean/ansi2html#61

ok, it seems my previous change only worked on our own systems for a while, this really should be python-six. 
Sorry for the noise.